### PR TITLE
#3716 Houdini Paths

### DIFF
--- a/python/tk_houdini/menu_generation.py
+++ b/python/tk_houdini/menu_generation.py
@@ -13,6 +13,8 @@ import sys
 import xml.etree.ElementTree as ET
 
 g_menu_item_script = os.path.join(os.path.dirname(__file__), "menu_action.py")
+
+# #3716 Fixes UNC problems with menus. Prefix '\' are otherwise concatenated to a single character, therefore using '/' instead.
 g_menu_item_script = g_menu_item_script.replace('\\', '/')
 
 


### PR DESCRIPTION
Fixes UNC issue (ie: \server\path) with path for houdini. The fix is to convert path to a format Houdini reads correctly. Otherwise, houdini was strips all prefix '\' to a single '\' which creates an error with paths starting with '\\'.
