### PR TITLE
#30708 fix to allow Shotgun shelf to work in houdini 13

### DIFF
--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -330,7 +330,7 @@ class AppCommand(object):
         if "app" in self.properties:
             app = self.properties["app"]
             doc_url = app.documentation_url
-            return doc_url
+            return str(doc_url)
 
         return None
 


### PR DESCRIPTION
Forces app help documentation url to a str before handing off to houdini tool creation.