### PR TITLE
 #29293 First pass at getting stylesheets looking nice in houdini

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -168,9 +168,6 @@ class HoudiniEngine(tank.platform.Engine):
                 app.setQuitOnLastWindowClosed(False)
                 app.setApplicationName(sys.argv[0])
 
-                # set the stylesheet
-                self._initialize_dark_look_and_feel()
-
             self.log_debug("No integrated PySide. Starting integrated event loop.")
             tk_houdini.python_qt_houdini.exec_(app)
 
@@ -180,6 +177,8 @@ class HoudiniEngine(tank.platform.Engine):
         QtCore.QTextCodec.setCodecForCStrings(utf8)
         self.log_debug("set utf-8 codec for widget text")
 
+        # set the stylesheet
+        self._initialize_dark_look_and_feel()
 
     def destroy_engine(self):
         """
@@ -578,5 +577,21 @@ class HoudiniEngine(tank.platform.Engine):
         # lastly, return the instantiated widget
         return widget
 
+    def _get_dialog_parent(self):
+        """
+        Get the QWidget parent for all dialogs created through show_dialog &
+        show_modal.
+        """
 
-    
+        # The hou api does not expose a main window for parenting. The default
+        # implementation of this method in core is to return the application's
+        # activeWindow(), but that can be unreliable as it can return None or
+        # another dialog that is being shown. In addition, houdini seems to do
+        # something odd regarding stylesheets/palettes once a custom widget is
+        # parented to one of its top level widgets. It appears to reset the
+        # widget's style and apply its own style which doesn't even match the
+        # rest of the houdini interface. It seems like the easiest way to avoid
+        # this for now is to not parent toolkit dialogs and use core's dark
+        # look and feel.
+        return None
+                

--- a/python/tk_houdini/__init__.py
+++ b/python/tk_houdini/__init__.py
@@ -14,6 +14,7 @@ from .ui_generation import (
     AppCommandsPanelHandler,
     get_registered_commands,
     get_registered_panels,
+    get_wrapped_panel_widget,
 )
 
 try:

--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -536,6 +536,66 @@ def get_registered_panels(engine):
         panels.append(AppCommand(panel_name, panel_details))
     return panels
 
+def get_wrapped_panel_widget(engine, widget_class, bundle, title):
+    """Returns a wrapped widget for use in a houdini python panel.
+
+    :param engine: The engine instance.
+    :param widget_class: The widget class to wrap.
+    :param bundle: The bundle associated with the panel being wrapped.
+    :param title: The title to display for this panel.
+
+    Here we subclass the panel widget in order to hijack the first paint event.
+    There, we force clear the parent's stylesheet and reset the widget with the
+    bundled stylesheet if there is one. This prevents houdini's parenting from
+    cramping the panel's style. We also filter for change events to detect when
+    something else attempts to change the style so we can force it back to the
+    bundled style. The first paint event isn't sufficient for panels saved in
+    desktops, but detecting style change seems to do the trick.
+
+    """
+
+    from tank.platform.qt import QtCore
+
+    # the wrapper
+    class PanelWrapper(widget_class):
+    
+        def __init__(self, *args, **kwargs):
+            super(PanelWrapper, self).__init__(*args, **kwargs)
+            self._stylesheet_applied = False
+            self._changing_stylesheet = False
+            self.installEventFilter(self)
+    
+        def eventFilter(self, obj, event):
+
+            # style change, we need to re-apply our own style
+            if event.type() == QtCore.QEvent.StyleChange:
+                if not self._changing_stylesheet:
+                    self._stylesheet_applied = False
+
+            # if we're about to paint, see if we need to re-apply the style
+            elif event.type() == QtCore.QEvent.Paint:
+                if not self._stylesheet_applied:
+                    self._apply_stylesheet()
+
+            return False
+
+        def _apply_stylesheet(self):
+
+            self._changing_stylesheet = True
+            try:
+                if self.parent():
+                    self.parent().setStyleSheet("")
+                engine._apply_external_styleshet(bundle, self)
+            except Exception:
+                engine.log_warning(
+                    "Unable to re-apply stylesheet for panel: %s" % (title,)
+                )
+            finally:
+                self._changing_stylesheet = False
+            self._stylesheet_applied = True
+
+    return PanelWrapper()
+
 # -----------------------------------------------------------------------------
 # internal:
 
@@ -596,6 +656,8 @@ _g_panel_script = \
 """
 from PySide import QtGui
 
+from tank.platform.qt import QtCore
+
 class NoPanelWidget(QtGui.QWidget):
     
     def __init__(self, msg, error=None):
@@ -603,9 +665,14 @@ class NoPanelWidget(QtGui.QWidget):
         super(NoPanelWidget, self).__init__()
 
         sg_icon_path = '%s'
-        
         sg_icon = QtGui.QLabel()
-        sg_icon.setPixmap(QtGui.QPixmap(sg_icon_path))
+
+        try:
+            sg_pixmap = QtGui.QPixmap(sg_icon_path).scaledToWidth(64, QtCore.Qt.SmoothTransformation)
+            sg_icon.setPixmap(sg_pixmap)
+        except:
+            pass
+
         msg_lbl = QtGui.QLabel(msg) 
         msg_lbl.setWordWrap(True)
 
@@ -617,6 +684,7 @@ class NoPanelWidget(QtGui.QWidget):
         h_layout.setSpacing(5)
         h_layout.addWidget(sg_icon)
         h_layout.addWidget(msg_lbl)
+        h_layout.setStretchFactor(msg_lbl, 10)
     
         v_layout = QtGui.QVBoxLayout(self)
         v_layout.setContentsMargins(10, 10, 10, 10)
@@ -635,7 +703,17 @@ def createInterface():
         return NoPanelWidget(
             "It looks like you're running Houdini outside of a Shotgun "
             "context. Next time you launch Houdini from within a Shotgun "
-            "context, you will see the %s here."
+            "context, you will see the '%s' here."
+        )
+
+    try:
+        engine = tank.platform.engine.current_engine()
+        panel_info = engine.get_panel_info('%s')
+        panel_widget = engine.get_wrapped_panel_widget(
+            engine,
+            panel_info['widget_class'],
+            panel_info['bundle'],
+            panel_info['title'],
         )
     except Exception:
         import traceback
@@ -644,48 +722,6 @@ def createInterface():
             "is provided below.",
             error=traceback.format_exc()
         )
-    
-    engine = tank.platform.engine.current_engine()
-    panel_info = engine.get_panel_info('%s')
-
-    from tank.platform.qt import QtCore
-
-    # here we subclass the panel widget in order to hijack the first paint
-    # event. There, we force clear the parent's stylesheet and reset the widget
-    # with the bundled sytlesheet if there is one. This prevents houdini's
-    # parenting from cramping the panel's style. We also override the
-    # changeEvent method to detect when something else attempts to change the
-    # style so we can force it back to the bundled style. The first paint event
-    # isn't sufficient for panels saved in desktops, but detecting style change
-    # seems to do the trick.
-    class PanelWidget(panel_info['widget_class']):
-    
-        def __init__(self, *args, **kwargs):
-            super(PanelWidget, self).__init__(*args, **kwargs)
-            self._stylesheet_applied = False
-            self._changing_stylesheet = False
-
-        def changeEvent(self, event):
-            if event.type() == QtCore.QEvent.StyleChange:
-                if not self._changing_stylesheet:
-                    self._stylesheet_applied = False
-            super(PanelWidget, self).changeEvent(event)
-    
-        def paintEvent(self, event):
-            if self.parent() and not self._stylesheet_applied:
-                self._changing_stylesheet = True
-                self.parent().setStyleSheet("")
-                engine._apply_external_styleshet(panel_info['bundle'], self)
-                self._changing_stylesheet = False
-                self._stylesheet_applied = True
-            super(PanelWidget, self).paintEvent(event)
-
-    panel_widget = PanelWidget()
-
-    if not panel_widget:
-        return NoPanelWidget(
-            "This panel is not available in this context." 
-        )
 
     pane_tab = kwargs["paneTab"]
     if pane_tab:
@@ -693,5 +729,6 @@ def createInterface():
         pane_tab.setName(panel_info['id'])
 
     return panel_widget
+
 """
 


### PR DESCRIPTION
This code addresses stylesheet issues encountered when using Toolkit apps in houdini. All toolkit apps (dialogs and panels) should now be consistent with other DCCs.

![screen shot 2015-11-02 at 9 15 27 pm](https://cloud.githubusercontent.com/assets/2604646/10899843/f26cab2c-81a6-11e5-8e1d-7b0da8e4d1e2.png)
