### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -47,6 +47,9 @@ class HoudiniEngine(tank.platform.Engine):
                 "Your version of Houdini is not supported on OS X. Currently, "
                 "Toolkit only supports version 14+ on OS X.")
 
+        hou_ver_str = ".".join([str(v) for v in hou.applicationVersion()])
+        self.log_user_attribute_metric("Houdini version", hou_ver_str)
+
         # keep track of if a UI exists
         self._ui_enabled = hasattr(hou, 'ui')
 

--- a/engine.py
+++ b/engine.py
@@ -47,8 +47,12 @@ class HoudiniEngine(tank.platform.Engine):
                 "Your version of Houdini is not supported on OS X. Currently, "
                 "Toolkit only supports version 14+ on OS X.")
 
-        hou_ver_str = ".".join([str(v) for v in hou.applicationVersion()])
-        self.log_user_attribute_metric("Houdini version", hou_ver_str)
+        try:
+            hou_ver_str = ".".join([str(v) for v in hou.applicationVersion()])
+            self.log_user_attribute_metric("Houdini version", hou_ver_str)
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
         # keep track of if a UI exists
         self._ui_enabled = hasattr(hou, 'ui')

--- a/info.yml
+++ b/info.yml
@@ -60,3 +60,5 @@ description: "Shotgun Pipeline Toolkit integration in Houdini"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.14.56"
+
+# XXX will require core version with metrics logging

--- a/info.yml
+++ b/info.yml
@@ -61,4 +61,3 @@ description: "Shotgun Pipeline Toolkit integration in Houdini"
 requires_shotgun_version:
 requires_core_version: "v0.14.56"
 
-# XXX will require core version with metrics logging


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.