### PR TITLE
 #36334 Adds support for Recent Files menu

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -80,6 +80,17 @@ class HoudiniEngine(tank.platform.Engine):
             else:
                 self.log_warning("PySide not bundled for python %d.%d" % (py_ver[0], py_ver[1]))
 
+    def pre_app_init(self):
+        """
+        Called at startup, but after QT has been initialized.
+        """
+
+        if not self._ui_enabled:
+            return
+
+        tk_houdini = self.import_module("tk_houdini")
+        tk_houdini.ensure_file_change_timer_running(self)
+
     def post_app_init(self):
         """
         Init that runs after all apps have been loaded.

--- a/engine.py
+++ b/engine.py
@@ -89,7 +89,7 @@ class HoudiniEngine(tank.platform.Engine):
             return
 
         tk_houdini = self.import_module("tk_houdini")
-        tk_houdini.ensure_file_change_timer_running(self)
+        tk_houdini.ensure_file_change_timer_running()
 
     def post_app_init(self):
         """

--- a/python/tk_houdini/__init__.py
+++ b/python/tk_houdini/__init__.py
@@ -12,6 +12,7 @@ from .ui_generation import (
     AppCommandsMenu,
     AppCommandsShelf,
     AppCommandsPanelHandler,
+    ensure_file_change_timer_running,
     get_registered_commands,
     get_registered_panels,
     get_wrapped_panel_widget,

--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -953,17 +953,20 @@ def _on_file_change_timeout():
             cur_engine.destroy()
         return
 
+    # get the new context from the file
     new_context = tk.context_from_path(cur_file, cur_context)
 
+    # if the contexts are the same, either the user has not changed context or
+    # the context change has already been handled, for example by workfiles2
     if cur_context == new_context:
         return
 
-    if cur_engine:
-        cur_engine.destroy()
-
     # try to create new engine
     try:
-        sgtk.platform.start_engine(engine_name, tk, new_context)
+        if cur_engine:
+            sgtk.platform.change_context(new_context)
+        else:
+            sgtk.platform.start_engine(engine_name, tk, new_context)
     except sgtk.TankEngineInitError, e:
         msg = (
             "There was a problem starting a new instance of the '%s' engine "


### PR DESCRIPTION
This is an initial implementation using a QTimer to poll for changes to the current hip file. I'm not 100% sure this is the best way, but it seems to work. Houdini does not seem to have a good way to hook into work file changes via callbacks.

These changes modify the dynamic menu system to insert a single menu item "Not working in a Shotgun context" when no engine can be found. When clicked, it pops up a warning dialog with additional information.

For versions of Houdini that don't support dynamic menus, I don't think anything can be done to disable or hide the menu. Those users don't expect a dynamic menu, so it is unlikely they'd be relying upon the Recent Files menu.

I'm waiting on a response from SESI to see if there may be a better way to do this. If we proceed with this solution, it will need some thorough QA.

![screen shot 2016-05-19 at 5 09 31 pm](https://cloud.githubusercontent.com/assets/2604646/15409815/7f99c898-1de4-11e6-94b2-e9b2a8bde259.png)

![screen shot 2016-05-19 at 5 06 56 pm](https://cloud.githubusercontent.com/assets/2604646/15409761/34f9c8f6-1de4-11e6-8f6b-fa93771dfbff.png)
