### PR TITLE
#37157 Safer logic for modifying HOUDINI_PATH during bootstrap

### DIFF
--- a/python/tk_houdini/bootstrap.py
+++ b/python/tk_houdini/bootstrap.py
@@ -36,7 +36,7 @@ def bootstrap(tank, context):
         # houdini respects semicolons as delimiters in all cases.
         hou_path_str = os.environ.get("HOUDINI_PATH")
         if hou_path_str:
-            hou_path_str.rstrip(";")
+            hou_path_str = hou_path_str.rstrip(";")
             hou_paths = hou_path_str.split(";")
         else:
             hou_paths = []
@@ -44,10 +44,7 @@ def bootstrap(tank, context):
         # paths to prepend that are not already in the houdini path
         prepend_paths = [tmpdir, engine_startup]
         prepend_paths = [p for p in prepend_paths if not p in hou_paths]
-
-        # reverse so that they're prepended in the right order
-        for path in reversed(prepend_paths):
-            hou_paths.insert(0, path)
+        prepend_paths.extend(hou_paths)
 
         # append the ampersand if it's not already in the paths
         if not "&" in hou_paths:

--- a/python/tk_houdini/bootstrap.py
+++ b/python/tk_houdini/bootstrap.py
@@ -32,13 +32,28 @@ def bootstrap(tank, context):
         engine_startup = os.path.join(os.path.dirname(__file__), "..", "..", "startup")
         engine_startup = os.path.normpath(engine_startup)
 
-        # include our directories in the HOUDINI_PATH
-        if 'HOUDINI_PATH' in os.environ:
-            old_path = os.environ['HOUDINI_PATH'].rstrip(';&')
-            new_path = "%s;%s;%s" % (tmpdir, engine_startup, old_path)
+        # note: not using sgtk.util.environment.prepend_path_to_env_var since
+        # houdini respects semicolons as delimiters in all cases.
+        hou_path_str = os.environ.get("HOUDINI_PATH")
+        if hou_path_str:
+            hou_path_str.rstrip(";")
+            hou_paths = hou_path_str.split(";")
         else:
-            new_path = "%s;%s" % (tmpdir, engine_startup)
-        os.environ['HOUDINI_PATH'] = "%s;&" % new_path
+            hou_paths = []
+
+        # paths to prepend that are not already in the houdini path
+        prepend_paths = [tmpdir, engine_startup]
+        prepend_paths = [p for p in prepend_paths if not p in hou_paths]
+
+        # reverse so that they're prepended in the right order
+        for path in reversed(prepend_paths):
+            hou_paths.insert(0, path)
+
+        # append the ampersand if it's not already in the paths
+        if not "&" in hou_paths:
+            hou_paths.append("&")
+
+        os.environ["HOUDINI_PATH"] = ";".join(hou_paths)
     except:
         # had an error, clean up the tmp dir
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
This change modifies the houdini engine bootstrap logic to be a little safer when modifying the `HOUDINI_PATH`. It now ensures that the additional paths are not already in `HOUDINI_PATH` before prepending/appending. This should resolve issues whereby multiple `&` could end up in the `HOUDINI_PATH` which was causing crashes in some scenarios.