### PR TITLE
#37814 Quick fix for houdini bug with help_url for shelf tools

### DIFF
--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -609,16 +609,18 @@ class AppCommandsShelf(AppCommandsUI):
             name=cmd.name.replace(" ", "_"),
             label=cmd.name,
             script=_g_launch_script % cmd.get_id(),
-            #help=cmd.get_description(),         
-            help_url=cmd.get_documentation_url_str(),
+            #help=cmd.get_description(),
+            #help_url=cmd.get_documentation_url_str(),
             icon=cmd.get_icon()
         )
         # NOTE: there seems to be a bug in houdini where the 'help' does
         # not display in the tool's tooltip even though the tool's help
         # string is clearly populated in the tool when you edit it in the
-        # ui. It is also causing popup errors related to getParsedTooltip 
+        # ui. It is also causing popup errors related to getParsedTooltip
         # in some builds. Leaving it commented out until this is fixed by
-        # SESI. 
+        # SESI.
+        # NOTE: Commenting out help_url due to apparent Houdini bug whereby
+        # empty url results in a ValueError on first mouseover. zd37814
 
         return tool
 


### PR DESCRIPTION
A one character change with a note. Basically, there appears to be a bug in Houdini whereby mousing over a shelf tool with `None` set to the `help_url` results in a `ValueError` being raised and shown in an error dialog. This circumvents the error for now by simply commenting out the parameter to include `help_url` when creating a new tool.

This is related to the `help` description issue worked around in 35617932cbcdc66da705a0a2cf403305d1a4413f