### PR TITLE
#37948 Use existing path separator, fallback to os.pathsep

### DIFF
--- a/python/tk_houdini/bootstrap.py
+++ b/python/tk_houdini/bootstrap.py
@@ -12,8 +12,6 @@ import os
 import shutil
 import tempfile
 
-import tank.platform.engine as tank_engine
-
 
 g_temp_env = 'TK_HOUDINI_TMP'
 
@@ -36,9 +34,33 @@ def bootstrap(tank, context):
         # houdini respects semicolons as delimiters in all cases.
         hou_path_str = os.environ.get("HOUDINI_PATH")
         if hou_path_str:
-            hou_path_str = hou_path_str.rstrip(";")
-            hou_paths = hou_path_str.split(";")
+
+            # It turns out Houdini allows HOUDINI_PATH to be separated by
+            # semicolons on any OS, so the tk engine has always supported and
+            # assumed semicolons regardless of the current OS. Some clients on
+            # POSIX OSs however, who define HOUDINI_PATH in their env prior to
+            # tk engine bootstrap, use colons as the path separator. This is
+            # completely valid and matches the POSIX convention. To account for
+            # the legacy behavior of this engine and the option to use either
+            # style in Houdini, we first check to see if HOUDINI_PATH is already
+            # using one separator or another. If it is, continue using the
+            # separator found in the path. If it is not already using a
+            # specific separator, fallback to the separator for the current OS.
+            if ":" in hou_path_str:
+                # colon found, continue using
+                path_sep = ":"
+            elif ";" in hou_path_str:
+                # semicolon found, continue using
+                path_sep = ";"
+            else:
+                # no existing separator. fall back to os separator
+                path_sep = os.pathsep
+
+            hou_path_str = hou_path_str.rstrip(path_sep)
+            hou_paths = hou_path_str.split(path_sep)
         else:
+            # use the os's path separator
+            path_sep = os.pathsep
             hou_paths = []
 
         # paths to prepend that are not already in the houdini path
@@ -52,7 +74,7 @@ def bootstrap(tank, context):
         if not "&" in hou_paths:
             new_paths.append("&")
 
-        os.environ["HOUDINI_PATH"] = ";".join(new_paths)
+        os.environ["HOUDINI_PATH"] = path_sep.join(new_paths)
     except:
         # had an error, clean up the tmp dir
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
This change removes the engine's assumption that `;` is always used as the `HOUDINI_PATH` separator. The bootstrap logic will now check to see if `HOUDINI_PATH` is defined and what separator it is using. If an existing separator is in use, the engine will continue with that separator as it prepends and appends additional paths required for engine bootstrap. If no separator is found, then OS-specific separator will be used. 