### PR TITLE
#37948 Use existing path separator, fallback to os.pathsep

### DIFF
--- a/python/tk_houdini/bootstrap.py
+++ b/python/tk_houdini/bootstrap.py
@@ -48,7 +48,7 @@ def bootstrap(tank, context):
             # tk engine bootstrap, use colons as the path separator. This is
             # completely valid and matches the POSIX convention.
 
-            if sys.platform != "win32":
+            if sys.platform is not "win32":
                 # for non-windows OS, see if semicolon is in use
                 if ";" in hou_path_str:
                     # already using semi-colons, continue using semicolons.

--- a/python/tk_houdini/bootstrap.py
+++ b/python/tk_houdini/bootstrap.py
@@ -52,7 +52,7 @@ def bootstrap(tank, context):
                 # for non-windows OS, see if semicolon is in use
                 if ";" in hou_path_str:
                     # already using semi-colons, continue using semicolons.
-                    # this will prevent clients relying on the legacy engine
+                    # this will allow clients relying on the legacy engine
                     # behavior to continue without making any changes.
                     path_sep = ";"
 


### PR DESCRIPTION
Update to previously unreleased logic (#19). Now only attempts to use in-use `;` separator on non-windows OSs. Windows should always use `;`. 