### PR TITLE
Adds setting to disable automatic context switch

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -94,7 +94,8 @@ class HoudiniEngine(tank.platform.Engine):
             # context. Make sure the timer that looks for current file changes
             # is running.
             tk_houdini = self.import_module("tk_houdini")
-            tk_houdini.ensure_file_change_timer_running()
+            if self.get_setting("automatic_context_switch", True):
+                tk_houdini.ensure_file_change_timer_running()
 
     def post_app_init(self):
         """

--- a/info.yml
+++ b/info.yml
@@ -14,6 +14,12 @@
 # expected fields in the configuration file for this engine
 configuration:
 
+    automatic_context_switch:
+        type: bool
+        description: "Controls whether toolkit should attempt to automatically adjust its
+                     context every time the currently loaded file changes. Defaults to True."
+        default_value: True
+
     enable_sg_menu:
         type: bool
         description: "Controls whether a menu will be built with commands


### PR DESCRIPTION
We were running into stability issues with the automatic context switch functionality in recent versions of the tk-houdini engine, and required a means of disabling it.

This also brings tk-houdini in line with the standard tk-maya engine which offers an identical option.

Let me know if this change looks okay!