### PR TITLE
For #44051 update Houdini engine of newer metrics API

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -27,7 +27,17 @@ class HoudiniEngine(tank.platform.Engine):
     """
     Houdini Engine implementation
     """
-    
+
+    @property
+    def host_info(self):
+        """
+        :returns: A {"name": application name, "version": application version}
+                  dictionary with informations about the application hosting this
+                  engine.
+        """
+        hou_ver_str = ".".join([str(v) for v in hou.applicationVersion()])
+        return {"name": "Houdini", "version": hou_ver_str}
+
     ############################################################################
     # init and basic properties
     ############################################################################
@@ -44,13 +54,6 @@ class HoudiniEngine(tank.platform.Engine):
                 "Your version of Houdini is not supported. Currently, Toolkit "
                 "only supports version 14+."
             )
-
-        try:
-            hou_ver_str = ".".join([str(v) for v in hou.applicationVersion()])
-            self.log_user_attribute_metric("Houdini version", hou_ver_str)
-        except:
-            # ignore all errors. ex: using a core that doesn't support metrics
-            pass
 
         # keep track of if a UI exists
         self._ui_enabled = hasattr(hou, 'ui')

--- a/engine.py
+++ b/engine.py
@@ -34,9 +34,22 @@ class HoudiniEngine(tank.platform.Engine):
         :returns: A {"name": application name, "version": application version}
                   dictionary with informations about the application hosting this
                   engine.
+
+        References:
+        latest: http://www.sidefx.com/docs/houdini/hom/hou/applicationVersion
         """
-        hou_ver_str = ".".join([str(v) for v in hou.applicationVersion()])
-        return {"name": "Houdini", "version": hou_ver_str}
+        host_info = {"name": "houdini", "version": "unknown"}
+
+        if hasattr(hou, "applicationVersionString"):
+            host_info["version"] = hou.applicationVersionString()
+        else:
+            # Fallback to older way
+            host_info["version"] = ".".join([str(v) for v in hou.applicationVersion()])
+
+        if hasattr(hou, "applicationName"):
+            host_info["name"] = hou.applicationName()
+
+        return host_info
 
     ############################################################################
     # init and basic properties


### PR DESCRIPTION
This is what it looks like on Amplitude from running my dev env. with latest Houdini

( just the 'event_properties' sub-structure )
```
 "event_properties": { "Engine": "tk-houdini", "Engine Version": "Dev-Nico", "Host App": "Houdini", "Host App Version": "16.0.705", "event_group": "Toolkit", "event_name": "Launched Engine", "event_type": "event", "from_api": true },
```