### PR TITLE
For #46152: Houdini 16+ Qt styling fixes.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -687,6 +687,16 @@ class HoudiniEngine(tank.platform.Engine):
 
         dialog, widget = self._create_dialog_with_widget(title, bundle, widget_class, *args, **kwargs)
 
+        # I don't have an answer to why this does what it does. We have
+        # a situation in H16 where some aspects of our widgets can't be
+        # styled...the changes just don't have any impact. However, if
+        # we re-apply the parent's stylesheet, unchanged, after we show
+        # our dialog, those styling changes we've applied either as part
+        # of the app's style.qss, or tk-houdini's, everything sticks the
+        # way it should.
+        if hou.applicationVersion() >= (16, 0, 0):
+            dialog.parent().setStyleSheet(dialog.parent().styleSheet())
+
         # finally launch it, modal state
         status = dialog.exec_()
         

--- a/engine.py
+++ b/engine.py
@@ -194,8 +194,13 @@ class HoudiniEngine(tank.platform.Engine):
         # workarounds when parenting toolkit widgets, allows for the
         # consistent, intended look and feel of the toolkit widgets.
         # Surprisingly, calling this does not seem to have any affect on
-        # houdini itself, despite the global nature of the method. 
-        self._initialize_dark_look_and_feel()
+        # houdini itself, despite the global nature of the method.
+        #
+        # NOTE: Except for 16+. It's no longer safe and causes lots of styling
+        # problems in Houdini's UI globally.
+        if hou.applicationVersion() < (16, 0, 0):
+            self.logger.debug("Houdini < 16 detected: applying dark look and feel.")
+            self._initialize_dark_look_and_feel()
 
         # Run a series of app instance commands at startup.
         self._run_app_instance_commands()
@@ -543,6 +548,16 @@ class HoudiniEngine(tank.platform.Engine):
     # UI Handling
     ############################################################################
 
+    def _get_engine_qss_file(self):
+        """
+        Returns the engine's style.qss file path.
+        """
+        from sgtk.platform import constants
+        return os.path.join(
+            self.disk_location,
+            constants.BUNDLE_STYLESHEET_FILE,
+        )
+
     def _create_dialog(self, title, bundle, widget, parent):
         """
         Overriden from the base Engine class - create a TankQDialog with the specified widget 
@@ -591,6 +606,14 @@ class HoudiniEngine(tank.platform.Engine):
         # TODO: Remove this when we re-enable panel support in H16 on OS X.
         if bundle.name == "tk-multi-shotgunpanel":
             self._apply_external_styleshet(bundle, dialog)
+
+            if hou.applicationVersion()[0] >= 16:
+                qss_file = self._get_engine_qss_file()
+                with open(qss_file, "rt") as f:
+                    qss_data = f.read()
+                    qss_data = self._resolve_sg_stylesheet_tokens(qss_data)
+                    widget.setStyleSheet(widget.styleSheet() + qss_data)
+                    widget.update()
         else:
             # manually re-apply any bundled stylesheet to the dialog if we are older
             # than H16. In 16 we inherited styling problems and need to rely on the

--- a/engine.py
+++ b/engine.py
@@ -621,6 +621,16 @@ class HoudiniEngine(tank.platform.Engine):
             if bundle.name == "tk-multi-shotgunpanel":
                 self._apply_external_styleshet(bundle, dialog)
 
+            # Styling in H16+ is very different than in earlier versions of
+            # Houdini. The result is that we have to be more careful about
+            # behavior concerning stylesheets, because we might bleed into
+            # Houdini itself if we change qss on parent objects or make use
+            # of QStyles on the QApplication.
+            #
+            # Below, we're combining the engine-level qss with whatever is
+            # already assigned to the widget. This means that the engine
+            # styling is helping patch holes in any app- or framework-level
+            # qss that might have already been applied.
             if hou.applicationVersion()[0] >= 16:
                 # We don't apply the engine's style.qss to the dialog for the panel,
                 # but we do for the publisher. This will make sure that the tank
@@ -634,8 +644,6 @@ class HoudiniEngine(tank.platform.Engine):
                 with open(qss_file, "rt") as f:
                     qss_data = f.read()
                     qss_data = self._resolve_sg_stylesheet_tokens(qss_data)
-                    # This basically means that the engine's qss wins out over
-                    # the app's when there's overlap between the two.
                     widget.setStyleSheet(widget.styleSheet() + qss_data)
                     widget.update()
         else:

--- a/style.qss
+++ b/style.qss
@@ -11,6 +11,72 @@ not expressly granted therein are reserved by Shotgun Software Inc.
 
 */
 
+QWidget {
+    background-color:  rgb(68, 68, 68);
+    color: rgb(185, 185, 185);
+    border-radius: 2px;
+    selection-background-color: rgb(167, 167, 167);
+    selection-color: rgb(26, 26, 26);
+    font-size: 11px;
+}
+
+QMenu {
+    color: rgb(75,75,75);
+}
+
+QGroupBox {
+    border: 2px solid rgb(40,40,40);
+    border-radius: 0px;
+    margin: 0em;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    border-radius: 0em;
+    margin-left: 0em;
+    padding: 0px 0px 0px 0px;
+    background-color: rgb(30,30,30);
+}
+
+QGroupBox::title {
+    color: rgb(200,200,200);
+}
+
+QFrame, QLineEdit, QComboBox, QSpinBox {
+    background-color: rgb(68, 68, 68);
+}
+
+QSpinBox {
+    background-color: rgb(68, 68, 68);
+    margin: 5px;
+}
+
+QAbstractItemView {
+    background-color: rgb(75, 75, 75);
+}
+
+QComboBox {
+    padding-top: 1px;
+    padding-left: 5px;
+    margin-left: 3px;
+    margin-right: 0px;
+}
+
+QComboBox::down-arrow {
+    background-color: transparent;
+}
+
+QLineEdit, QTextEdit {
+    margin: 3px;
+    background: rgb(40, 40, 40);
+}
+
+QLabel {
+    background-color: none;
+    border:none;
+}
+
 /*tabwidget*/
 QTabWidget {
     background-color: #323232;
@@ -28,40 +94,100 @@ QTabBar::tab:selected {
     background-color: #323232;
 }
 
-QPushButton {
-    background-color: rgb(50, 50, 50);
-    border-radius: 4px;
-    padding: 5px 10px 5px 10px;
-    min-width: 60px;
-}
-
-QPushButton::pressed {
-    background-color: #272727;
-}
-
-QPushButton:disabled {
-    background-color: rgb(75, 75, 75);
-}
-
-QToolButton {
-    background-color: rgb(50, 50, 50);
-    border-radius: 4px;
-    padding: 5px 10px 5px 10px;
-}
-
-QToolButton::pressed {
-    background-color: #272727;
-}
-
-QToolButton:disabled {
-    background-color: rgb(75, 75, 75);
-}
-
 QTabWidget::pane {
     border: 1px solid #323232;
 }
 
-QLineEdit, QComboBox, QSpinBox, QScrollBar {
-    background-color: #272727;
-    border: 1px solid #323232;
+QTabWidget::tab-bar {
+    alignment: left;
 }
+
+/*radiobuttons+checkboxes*/
+QRadioButton, QCheckBox {
+    background: transparent;
+    border: 0px solid;
+    padding: 0px;
+}
+
+QRadioButton:disabled, QCheckBox:disabled {
+    background: transparent;
+    color: rgb(120, 120, 120);
+}
+
+/*Push Button*/
+
+QPushButton {
+    color: rgb(195, 195, 195);
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 rgb(95,95,95), stop:1 rgb(85,85,85));
+    border-width: 1px;
+    border-color: rgb(40, 40, 40);
+    border-style: solid;
+    border-radius: 3;
+    padding-top: 3px;
+    padding-bottom: 3px;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+QToolButton {
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 rgb(95,95,95), stop:1 rgb(85,85,85));
+    border-style: solid;
+    border-radius: 3;
+    border-width: 1px;
+    border-color: rgb(40, 40, 40);
+    padding-top: 3px;
+    padding-bottom: 3px;
+    padding-left: 3px;
+    padding-right: 3px;
+}
+
+QPushButton:pressed, QToolButton:pressed {
+    background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #2d2d2d, stop: 0.1 #2b2b2b, stop: 0.5 #292929, stop: 0.9 #282828, stop: 1 #252525);
+}
+
+QPushButton:hover, QToolButton:hover {
+    border: 1px solid {{SG_HIGHLIGHT_COLOR}};
+}
+
+QPushButton[flat=true] {
+    padding-right: 3px;
+    padding-left: 3px;
+    background: transparent;
+    border: none;
+    border-radius: 0px;
+}
+
+QScrollBar::handle:vertical {
+    background-color: rgb(75,75,75);
+    border: 0px solid;
+    border-radius: 3px;
+}
+
+QScrollBar::vertical {
+    background: rgb(50,50,50);
+    padding: 2px;
+    margin: 0px;
+    width: 8px;
+}
+
+QScrollBar::handle:horizontal {
+    background-color: rgb(75,75,75);
+    border: 0px solid;
+    border-radius: 3px;
+}
+
+QScrollBar::horizontal {
+    background: rgb(50,50,50);
+    padding: 2px;
+    margin: 0px;
+}
+
+SearchWidget {
+    padding: 4px;
+}
+
+QDockWidget {
+    border: none;
+}
+
+

--- a/style.qss
+++ b/style.qss
@@ -12,9 +12,9 @@ not expressly granted therein are reserved by Shotgun Software Inc.
 */
 
 QWidget {
-    background-color:  rgb(68, 68, 68);
+    background-color: rgb(68, 68, 68);
     color: rgb(185, 185, 185);
-    border-radius: 2px;
+    border-radius: 0px;
     selection-background-color: rgb(167, 167, 167);
     selection-color: rgb(26, 26, 26);
     font-size: 11px;
@@ -67,7 +67,7 @@ QComboBox::down-arrow {
     background-color: transparent;
 }
 
-QLineEdit, QTextEdit {
+QLineEdit, QTextEdit, QPlainTextEdit {
     margin: 3px;
     background: rgb(40, 40, 40);
 }
@@ -88,6 +88,8 @@ QTabBar::tab {
     min-width: 50px;
     margin-left: 2px;
     margin-right: 2px;
+    margin-top: -5px;
+    margin-bottom: -5px;
 }
 
 QTabBar::tab:selected {
@@ -186,8 +188,32 @@ SearchWidget {
     padding: 4px;
 }
 
-QDockWidget {
-    border: none;
+/*
+    Styling specific to tk-multi-publish2.
+*/
+
+#items_tree::branch {
+    background-color: transparent;
 }
+
+#items_tree::branch:selected {
+    background-color: {{SG_HIGHLIGHT_COLOR}};
+}
+
+#items_tree::item:selected {
+    border-color: rgb(41,41,41);
+}
+
+#items_tree::item {
+    border-right-color: rgb(41,41,41);
+}
+
+#progress_bar {
+    background-color: rgb(120, 120, 120);
+}
+
+
+
+
 
 


### PR DESCRIPTION
Our old approach to styling from H15 and under causes problems with H16.x, where some of our style changes bleed into Houdini's dialogs. As such, we've had to take a different approach to styling for H16+.