### PR TITLE
For #46766: Removes call to setName on the pane tab object.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -27,6 +27,7 @@ class HoudiniEngine(tank.platform.Engine):
     """
     Houdini Engine implementation
     """
+    _pane_cache = dict()
 
     @property
     def host_info(self):
@@ -75,7 +76,6 @@ class HoudiniEngine(tank.platform.Engine):
         """
         Called at startup, but after QT has been initialized.
         """
-
         if not self._ui_enabled:
             return
 
@@ -322,6 +322,15 @@ class HoudiniEngine(tank.platform.Engine):
         # try to locate the pane in the desktop and make it the current tab. 
         for pane_tab in hou.ui.curDesktop().paneTabs():
             if pane_tab.name() == panel_id:
+                pane_tab.setIsCurrentTab()
+                return
+
+            # A secondary check is to look at a cache we hold mapping the title
+            # of the panel to a pane tab that already exists. We use the title
+            # here instead of the panel id because it's the only bit of information
+            # we have reliable access to from all of the various methods of
+            # showing pane tabs in Houdini.
+            if pane_tab.name() == self._pane_cache.get(title):
                 pane_tab.setIsCurrentTab()
                 return
 

--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -1118,9 +1118,18 @@ def createInterface():
     # make sure it has the 'setLabel' method available. that at least implies
     # that it is a python panel 
     if pane_tab and hasattr(pane_tab, 'setLabel'):
-        title = panel_info.get('title', None)
+        title = panel_info.get('title')
         if title:
             pane_tab.setLabel(title)
+
+            # We're caching here based on title, because it's the
+            # bit of information we have that's reliably available
+            # from all of the various methods of showing this
+            # pane tab. We cache the pane tab's name so that if a
+            # second invokation of showing this particular panel is
+            # triggered, we just show that panel rather than opening
+            # a second instance.
+            engine._pane_cache[title] = pane_tab.name()
 
     return panel_widget
 

--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -1119,11 +1119,8 @@ def createInterface():
     # that it is a python panel 
     if pane_tab and hasattr(pane_tab, 'setLabel'):
         title = panel_info.get('title', None)
-        name = panel_info.get('id', None)
         if title:
             pane_tab.setLabel(title)
-        if name:
-            pane_tab.setName(name)
 
     return panel_widget
 


### PR DESCRIPTION
Changing the name of a pane tab during interface creation breaks Houdini in bad ways, and I don't see why it's needed. I'm waiting to hear back final details from SESI, but I believe the situation is that the pane is looked up by name when it's selected from the menu, and Houdini is caching that name. The createInterface function is called, which renames the pane out from under Houdini, which then does another lookup using the old name, and it blows up with an unhandled exception.

SESI has a repro case now without Toolkit involved, but regardless of what they do with that, I feel like we're safe in removing the rename of the pane tab.

**UPDATE:** Setting the pane tab name is part of the mechanism that ensures only a single panel instance exists. However, discussing the issue with SESI, we're not going to be able to do this safely, at least for the time being. We'll have to live without this behavior as a result.

**UPDATE 2:** Most of the mechanism mentioned in the previous update still works, and the portion of it that's impacted by this change was already wonky and didn't work in all situations anyway. The result is that we still get correct behavior when launching the panel from the Shotgun menu, but it's possible to end up with duplicate panels if you're launching it from the pane menus. Given that there were already ways to end up with dups using the pane menus, this isn't going to have a major impact on UX.