### PR TITLE
For SG-2898: Fix for slow Houdini startup when launched from a Task.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -191,7 +191,16 @@ class HoudiniEngine(sgtk.platform.Engine):
             oplibrary_path = os.environ[bootstrap.g_temp_env].replace("\\", "/")
 
             # Setup the OTLs that need to be loaded for the Toolkit apps
-            self._load_otls(oplibrary_path)
+            def _load_otls():
+                self._load_otls(oplibrary_path)
+
+            # We have the same problem here on Windows that we have above with
+            # the population of the shelf. If we defer the execution of the otl
+            # loading by an event loop cycle, Houdini loads up quickly.
+            if sys.platform.startswith("win"):
+                QtCore.QTimer.singleShot(1, _load_otls)
+            else:
+                _load_otls()
 
         # tell QT to interpret C strings as utf-8
         utf8 = QtCore.QTextCodec.codecForName("utf-8")


### PR DESCRIPTION
We have the same slow startup problem as before, but for a different reason. When launched from an environment that contains Toolkit apps that require Houdini to import an otls, we see very slow startup times. The fix is the exact same as in #33, but applied to the otl loading logic.