### PR TITLE
For SG-6604: Applies the same checkbox pathing logic to panels as to dialogs.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -589,6 +589,14 @@ class HoudiniEngine(sgtk.platform.Engine):
             constants.BUNDLE_STYLESHEET_FILE,
         )
 
+    def _get_engine_root_path(self):
+        """
+        Returns the path to the directory containing this engine.py.
+        """
+        # Handle the Windows situation where __file__ is going to contain backslash
+        # delimiters.
+        return "/".join(os.path.dirname(__file__).split(os.path.sep))
+
     def _create_dialog(self, title, bundle, widget, parent):
         """
         Overriden from the base Engine class - create a TankQDialog with the specified widget 
@@ -648,10 +656,7 @@ class HoudiniEngine(sgtk.platform.Engine):
         # style.qss. So we'll treat this similarly to the way we treat the panel
         # and combine the two into a single, unified stylesheet for the dialog
         # and widget.
-        #
-        # Handle the Windows situation where __file__ is going to contain backslash
-        # delimiters.
-        engine_root_path = "/".join(os.path.dirname(__file__).split(os.path.sep))
+        engine_root_path = self._get_engine_root_path()
 
         if bundle.name in ["tk-multi-shotgunpanel", "tk-multi-publish2"]:
             if bundle.name == "tk-multi-shotgunpanel":

--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -862,6 +862,7 @@ def get_wrapped_panel_widget(engine, widget_class, bundle, title):
                     with open(qss_file, "rt") as f:
                         qss_data = f.read()
                         qss_data = engine._resolve_sg_stylesheet_tokens(qss_data)
+                        qss_data = qss_data.replace("{{ENGINE_ROOT_PATH}}", engine._get_engine_root_path())
                         self.setStyleSheet(self.styleSheet() + qss_data)
                         self.update()
 


### PR DESCRIPTION
A previous fix for checkbox styling hadn't been properly applied to panel apps. This resulted in a warning being printed in the Python console when panel apps were launched, because the qss includes a token that needed to be replaced with the engine root path prior to being applied.