### PR TITLE
Update to support Houdini 16.5.481 and up / PYSIDE-439 Fixed

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -710,9 +710,12 @@ class HoudiniEngine(sgtk.platform.Engine):
 
         # special case to get windows to raise the dialog
         if sys.platform == "win32":
-            ctypes.pythonapi.PyCObject_AsVoidPtr.restype = ctypes.c_void_p
-            ctypes.pythonapi.PyCObject_AsVoidPtr.argtypes = [ctypes.py_object]
-            hwnd = ctypes.pythonapi.PyCObject_AsVoidPtr(dialog.winId())
+            if hou.applicationVersion() >= (16, 5, 481):
+                hwnd = dialog.winId()
+            else:
+                ctypes.pythonapi.PyCObject_AsVoidPtr.restype = ctypes.c_void_p
+                ctypes.pythonapi.PyCObject_AsVoidPtr.argtypes = [ctypes.py_object]
+                hwnd = ctypes.pythonapi.PyCObject_AsVoidPtr(dialog.winId())
             ctypes.windll.user32.SetActiveWindow(hwnd)
 
         return dialog


### PR DESCRIPTION
Updated the _create_dialog method for windows since the workaround for dialog.winId() is no longer needed. winId() now returns the correct type and is no longer an opaque PyCObject.