### PR TITLE
SG-9210: Resolves various issues in H17.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -449,7 +449,9 @@ class HoudiniEngine(sgtk.platform.Engine):
             # to proceed. Until that is sorted out, though, we're going to
             # have to disable panel support on OS X for H16. Our panel apps
             # appear to function just fine in dialog mode.
-            if ver >= (16, 0, 0):
+            #
+            # Update: H17 resolves the panel issues we had in H16.
+            if ver >= (16, 0, 0) and ver <= (17, 0, 0):
                 return False
 
         if ver >= (15, 0, 272):

--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -13,7 +13,13 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 
-g_menu_item_script = os.path.join(os.path.dirname(__file__), "menu_action.py")
+# Make sure we always give Houdini forward-slash-delimited paths. There is
+# a crash bug in early releases of H17 on Windows when it's given backslash
+# paths to read.
+g_menu_item_script = os.path.join(
+    os.path.dirname(__file__),
+    "menu_action.py"
+).replace(os.path.sep, "/")
 
 # #3716 Fixes UNC problems with menus. Prefix '\' are otherwise concatenated to a single character, therefore using '/' instead.
 g_menu_item_script = g_menu_item_script.replace("\\", "/")
@@ -708,7 +714,7 @@ def get_registered_commands(engine):
 
     commands = []
 
-    sg_icon = os.path.join(engine.disk_location, "resources",
+    sg_icon = engine._safe_path_join(engine.disk_location, "resources",
         "shotgun_logo.png")
 
     jump_to_sg_cmd = AppCommand(
@@ -728,7 +734,7 @@ def get_registered_commands(engine):
     if engine.context.filesystem_locations:
         # Only show the jump to fs command if there are folders on disk.
 
-        fs_icon = os.path.join(engine.disk_location, "resources",
+        fs_icon = engine._safe_path_join(engine.disk_location, "resources",
             "shotgun_folder.png")
 
         jump_to_fs_cmd = AppCommand(

--- a/style.qss
+++ b/style.qss
@@ -96,6 +96,11 @@ QTabBar::tab:selected {
     background-color: #323232;
 }
 
+QTabBar::tab:disabled {
+    background-color: transparent;
+    border: none;
+}
+
 QTabWidget::pane {
     border: 1px solid #323232;
 }

--- a/style.qss
+++ b/style.qss
@@ -165,6 +165,30 @@ QToolButton {
     padding-right: 3px;
 }
 
+/* QTankDialog buttons */
+
+QToolButton#btn_reload {
+    width: 127px;
+}
+
+QToolButton#btn_documentation {
+    width: 80px;
+}
+
+QToolButton#btn_support {
+    width: 80px;
+}
+
+QToolButton#btn_file_system {
+    width: 106px;
+}
+
+QToolButton#btn_shotgun {
+    width: 90px;
+}
+
+/* End QTankDialog buttons */
+
 QPushButton:pressed, QToolButton:pressed {
     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #2d2d2d, stop: 0.1 #2b2b2b, stop: 0.5 #292929, stop: 0.9 #282828, stop: 1 #252525);
 }


### PR DESCRIPTION
Resolves two primary issues in Houdini 17.x:

- TabWidget styling fix for a bug that caused disabled tabs to still be visible, but not selectable, due to their background color and border.
- We now always give Houdini forward-slash delimited paths. There are multiple bugs in early releases of H17 (and one that still exists) that caused Houdini to crash if it was given backslash-delimited paths on Windows.