### PR TITLE
SG-14349 Fixes the open file on startup behaviour

### DIFF
--- a/python/tk_houdini/bootstrap.py
+++ b/python/tk_houdini/bootstrap.py
@@ -29,9 +29,6 @@ g_sgtk_context_env = "TANK_CONTEXT"
 # classic toolkit bootstrap
 g_sgtk_engine_env = "TANK_ENGINE"
 
-# Name of the file to open after bootstrap
-g_sgtk_file_to_open_env = "TANK_FILE_TO_OPEN"
-
 ################################################################################
 # methods for bootstrapping toolkit within houdini
 
@@ -96,16 +93,9 @@ def bootstrap_classic():
         )
         return
 
-    # see if the environment includes a file to be opened after bootstrap
-    file_to_open = os.environ.get(g_sgtk_file_to_open_env)
-    if file_to_open:
-        # importing here since we don't need hou unless loading a file
-        import hou
-        hou.hipFile.load(file_to_open)
-
     # clean env vars. note, we don't clean the temp dir env variable since it is
     # used by the engine to know where to write the shelf/menu .xml files
-    for env_var in [g_sgtk_context_env, g_sgtk_engine_env, g_sgtk_file_to_open_env]:
+    for env_var in [g_sgtk_context_env, g_sgtk_engine_env]:
         if env_var in os.environ:
             del os.environ[env_var]
 

--- a/startup.py
+++ b/startup.py
@@ -124,11 +124,9 @@ class HoudiniLauncher(SoftwareLauncher):
             required_env[engine_env] = self.engine_name
             required_env[context_env] = sgtk.context.serialize(self.context)
 
-        # populate the file to open env. Note this env variable name existed
-        # pre software launch setup.
         if file_to_open:
-            file_to_open_env = bootstrap.g_sgtk_file_to_open_env
-            required_env[file_to_open_env] = file_to_open
+            # If we have a file to open, add it to the end of the args so Houdini opens the file.
+            args = " ".join([args, file_to_open])
 
         self.logger.debug("Launch environment: %s" % (required_env,))
 


### PR DESCRIPTION
Previously if you provided a file to open on start up, Houdini 17 would crash.

It seems that perhaps the logic is being run too early in the Houdini startup process, I'm not certain.
Instead I've opted to set the file to open as an arg to the Houdini executable, and let Houdini handle the opening.

Related to:
https://github.com/shotgunsoftware/tk-shotgun-launchpublish/pull/7
and Similar to:
https://github.com/shotgunsoftware/tk-photoshopcc/pull/68
https://github.com/shotgunsoftware/tk-aftereffects/pull/29