### PR TITLE
SG-15250: Works around an H18 crash bug on OSX.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -671,9 +671,13 @@ class HoudiniEngine(sgtk.platform.Engine):
 
             # This will ensure our dialogs don't fall behind Houdini's main
             # window when they lose focus.
-            if sys.platform.startswith("darwin"):
-                dialog.setWindowFlags(
-                    dialog.windowFlags() | QtCore.Qt.Tool)
+            #
+            # NOTE: Setting the window flags in H18 on OSX causes a crash. Once
+            # that bug is resolved we can re-enable this. The result is that
+            # on H18 without the window flags set per the below, our dialogs
+            # will fall behind Houdini if they lose focus.
+            if sys.platform.startswith("darwin") and hou.applicationVersion()[0] < 18:
+                dialog.setWindowFlags(dialog.windowFlags() | QtCore.Qt.Tool)
         else:
             # no parent found, so style should be ok. this is probably,
             # hopefully, a rare case, but since our logic for identifying the
@@ -681,8 +685,7 @@ class HoudiniEngine(sgtk.platform.Engine):
             # assumptions, we should account for this case. set window flag to
             # be on top so that it doesn't duck under the houdini window when
             # shown (typicaly for windows)
-            dialog.setWindowFlags(
-                dialog.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
+            dialog.setWindowFlags(dialog.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
 
         # A bit of a hack here, which goes along with the disabling of panel support
         # for H16 on OS X. Because of that, we are also having to treat the panel
@@ -699,6 +702,7 @@ class HoudiniEngine(sgtk.platform.Engine):
         # and combine the two into a single, unified stylesheet for the dialog
         # and widget.
         engine_root_path = self._get_engine_root_path()
+        h_major_ver = hou.applicationVersion()[0]
 
         if bundle.name in ["tk-multi-shotgunpanel", "tk-multi-publish2"]:
             if bundle.name == "tk-multi-shotgunpanel":
@@ -714,7 +718,7 @@ class HoudiniEngine(sgtk.platform.Engine):
             # already assigned to the widget. This means that the engine
             # styling is helping patch holes in any app- or framework-level
             # qss that might have already been applied.
-            if hou.applicationVersion()[0] >= 16:
+            if h_major_ver >= 16:
                 # We don't apply the engine's style.qss to the dialog for the panel,
                 # but we do for the publisher. This will make sure that the tank
                 # dialog's header and info slide-out widget is properly styled. The
@@ -736,7 +740,7 @@ class HoudiniEngine(sgtk.platform.Engine):
             # engine level qss only.
             #
             # If we're in 16+, we also need to apply the engine-level qss.
-            if hou.applicationVersion()[0] >= 16:
+            if h_major_ver >= 16:
                 self._apply_external_styleshet(self, dialog)
                 qss = dialog.styleSheet()
                 qss = qss.replace("{{ENGINE_ROOT_PATH}}", engine_root_path)

--- a/engine.py
+++ b/engine.py
@@ -270,9 +270,9 @@ class HoudiniEngine(sgtk.platform.Engine):
             def run_when_idle():
                 hou.ui.displayMessage(
                     text="Houdini 18 versions older than 18.0.348 are unstable when using Shotgun "
-                        "Toolkit. Be aware that Houdini crashes may occur if attempting to use "
-                        "Toolkit apps from your current Houdini session. Shotgun recommends updating "
-                        "Houdini to 18.0.348 or newer.",
+                         "Toolkit. Be aware that Houdini crashes may occur if attempting to use "
+                         "Toolkit apps from your current Houdini session. Shotgun recommends updating "
+                         "Houdini to 18.0.348 or newer.",
                     title="Shotgun Toolkit",
                     severity=hou.severityType.Warning,
                 )

--- a/engine.py
+++ b/engine.py
@@ -655,6 +655,8 @@ class HoudiniEngine(sgtk.platform.Engine):
         # call the base implementation to create the dialog:
         dialog = sgtk.platform.Engine._create_dialog(self, title, bundle, widget, parent)
 
+        h_ver = hou.applicationVersion()
+
         if dialog.parent():
             # parenting crushes the dialog's style. This seems to work to reset
             # the style to the dark look and feel in preparation for the
@@ -666,7 +668,7 @@ class HoudiniEngine(sgtk.platform.Engine):
             # we break its styling in a few places if we zero out the main window's
             # stylesheet. We're now compensating for the problems that arise in
             # the engine's style.qss.
-            if hou.applicationVersion() < (16, 0, 0):
+            if h_ver < (16, 0, 0):
                 dialog.parent().setStyleSheet("")
 
             # This will ensure our dialogs don't fall behind Houdini's main
@@ -675,8 +677,9 @@ class HoudiniEngine(sgtk.platform.Engine):
             # NOTE: Setting the window flags in H18 on OSX causes a crash. Once
             # that bug is resolved we can re-enable this. The result is that
             # on H18 without the window flags set per the below, our dialogs
-            # will fall behind Houdini if they lose focus.
-            if sys.platform.startswith("darwin") and hou.applicationVersion()[0] < 18:
+            # will fall behind Houdini if they lose focus. This is only an issue
+            # for versions of H18 older than 18.0.348.
+            if sys.platform.startswith("darwin") and (h_ver[0] == 18 and h_ver >= (18, 0, 348)):
                 dialog.setWindowFlags(dialog.windowFlags() | QtCore.Qt.Tool)
         else:
             # no parent found, so style should be ok. this is probably,


### PR DESCRIPTION
This is a workaround and not a real solution. I've reproduced this bug (and a couple others related to PySide2) outside of Toolkit and have sent along repro steps and example code to our contact at SideFx to see if they can get them addressed for us. When they do, we'll expand the version check to only exclude the pre-fix H18 releases from the window flags setting.

The end result of this is no crash, but our dialogs fall behind Houdini if they lose focus. We'll have to live with that for now in H18, as I've not found a way to make that work without crashing Houdini.