### PR TITLE
SG-8384 Allows otl files to be loaded from version specific folders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-houdini?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=63&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/engine.py
+++ b/engine.py
@@ -568,6 +568,8 @@ class HoudiniEngine(sgtk.platform.Engine):
         if not os.path.exists(otl_path):
             return []
 
+        # Add the root otl folder to the list of paths to check, so as to maintain
+        # backwards compatibility, with apps that may not have version folder otls.
         otl_paths = [otl_path]
 
         # Check for Houdini version folder containing version specific otl files.

--- a/engine.py
+++ b/engine.py
@@ -574,30 +574,34 @@ class HoudiniEngine(sgtk.platform.Engine):
         version_folder = None
         for filename in os.listdir(otl_path):
             full_path = self._safe_path_join(otl_path, filename)
-            if os.path.isdir(full_path):
-                # https://regex101.com/r/3ujhFJ/2
-                # matches folder in the following format vx.x.x where "x" is either
-                # actually an x character or any number.
-                matches = re.search(r"^v(\d+|x).(\d+|x).(\d+|x)$", filename)
-                if matches:
-                    # Now we have a version folder, check to see if the folder version
-                    # is less than or equal to the current Houdini session version,
-                    # as we don't want to use otls for versions higher than our current version,
-                    if self._is_version_less_or_equal(
-                        matches.groups(), self._houdini_version
-                    ):
-                        # The folder version could be used so we should now check if it is more suitable
-                        # than any folder versions we have previously found. Ultimately we want to
-                        # find a version number folder that is lower but as closely matches
-                        # our current Houdini version.
-                        if version_folder is None or self._is_version_less_or_equal(
-                            version_folder[0], matches.groups()
-                        ):
-                            # Either there is no previous match, in which case set this match
-                            # as the current one to import, or the current match is less than the
-                            # new match, so we should use the new match.
-                            # Don't import yet, wait for all matches to be compared.
-                            version_folder = (matches.groups(), full_path)
+            if not os.path.isdir(full_path):
+                continue
+
+            # https://regex101.com/r/3ujhFJ/2
+            # matches folder in the following format vx.x.x where "x" is either
+            # actually an x character or any number.
+            matches = re.search(r"^v(\d+|x).(\d+|x).(\d+|x)$", filename)
+            if not matches:
+                continue
+            # Now we have a version folder, check to see if the folder version
+            # is less than or equal to the current Houdini session version,
+            # as we don't want to use otls for versions higher than our current version,
+            if not self._is_version_less_or_equal(
+                matches.groups(), self._houdini_version
+            ):
+                continue
+            # The folder version could be used so we should now check if it is more suitable
+            # than any folder versions we have previously found. Ultimately we want to
+            # find a version number folder that is lower but as closely matches
+            # our current Houdini version.
+            if version_folder is None or self._is_version_less_or_equal(
+                version_folder[0], matches.groups()
+            ):
+                # Either there is no previous match, in which case set this match
+                # as the current one to import, or the current match is less than the
+                # new match, so we should use the new match.
+                # Don't import yet, wait for all matches to be compared.
+                version_folder = (matches.groups(), full_path)
 
         if version_folder:
             # We found a version specific otl folder install any otls in that.

--- a/engine.py
+++ b/engine.py
@@ -577,8 +577,7 @@ class HoudiniEngine(sgtk.platform.Engine):
             if os.path.isdir(full_path):
                 # https://regex101.com/r/3ujhFJ/2
                 # matches folder in the following format vx.x.x where "x" is either
-                # actually an x character or a number.
-                # x means any value.
+                # actually an x character or any number.
                 matches = re.search(r"^v(\d+|x).(\d+|x).(\d+|x)$", filename)
                 if matches:
                     # Now we have a version folder, check to see if the folder version
@@ -589,7 +588,8 @@ class HoudiniEngine(sgtk.platform.Engine):
                     ):
                         # The folder version could be used so we should now check if it is more suitable
                         # than any folder versions we have previously found. Ultimately we want to
-                        # find a version number folder that as closely matches our current Houdini version.
+                        # find a version number folder that is lower but as closely matches
+                        # our current Houdini version.
                         if version_folder is None or self._is_version_less_or_equal(
                             version_folder[0], matches.groups()
                         ):

--- a/tests/fixtures/config/core/templates.yml
+++ b/tests/fixtures/config/core/templates.yml
@@ -64,6 +64,9 @@ paths:
     publish_path:
         definition: '@publish_area/{name}.v{version}.hip'
 
+    alembic_cache:
+        definition: '@publish_area/{name}.v{version}.abc'
+
     snapshot:
         definition: '@asset_root/{Task}/snapshots/{name}.v{version}.{timestamp}.hip'
 

--- a/tests/fixtures/config/env/task.yml
+++ b/tests/fixtures/config/env/task.yml
@@ -16,6 +16,14 @@ engines:
       path: '$SHOTGUN_CURRENT_REPO_ROOT'
 
     apps:
+      tk-houdini-alembicnode:
+        location: {'type': 'dev', 'path': '$SHOTGUN_REPOS_ROOT/tk-houdini-alembicnode'}
+        work_file_template: work_path
+        output_profiles:
+          - name: Shot Work Cache
+            settings: {}
+            color: []
+            output_cache_template: alembic_cache
       tk-multi-workfiles2:
         location: {'type': 'dev', 'path': '$SHOTGUN_REPOS_ROOT/tk-multi-workfiles2'}
       tk-multi-loader2:

--- a/tests/test_otl_loading.py
+++ b/tests/test_otl_loading.py
@@ -112,13 +112,6 @@ class TestLoadingOtls(TestHooks):
         alembic_app = self.engine.apps["tk-houdini-alembicnode"]
         otl_path = self.engine._safe_path_join(alembic_app.disk_location, "otls")
 
-        # This would normally happen when the engine starts up, but the
-        # `if bootstrap.g_temp_env in os.environ:` line prevents it from running
-        # during the tests. This might be down to us using a 123.py startup script
-        # I'm not sure at the time of writing.
-        # So we will call it manually.
-        self.engine._load_app_otls(self.tank_temp)
-
         # The alembic node should have version folders, so remove root folder from the list,
         # and check that we have one path left which will be the version folder.
         otl_paths = self.engine._get_otl_paths(otl_path)

--- a/tests/test_otl_loading.py
+++ b/tests/test_otl_loading.py
@@ -26,6 +26,12 @@ class TestLoadingOtls(TestHooks):
         super(TestLoadingOtls, self).setUp()
 
     def __check_paths(self, houdini_version, expected_folders):
+        """
+        Checks that the expected folders are gathered for the correct Houdini version.
+        :param houdini_version: The version of Houdini as a tuple of three ints.
+        :param expected_folders: The list of paths that we expect want to compare against the engine generated ones.
+        :return:
+        """
         # Change what the engine thinks the Houdini version is.
         self.engine._houdini_version = houdini_version
         # Ask the engine for the otl paths.
@@ -40,6 +46,11 @@ class TestLoadingOtls(TestHooks):
         )
 
     def _make_folder(self, folder_name):
+        """
+        Makes a folder in the app's otl folder with the provided name.
+        :param folder_name:
+        :return:
+        """
         os.makedirs(os.path.join(self.app_otl_folder, folder_name))
 
     def test_otl_paths(self):
@@ -92,6 +103,10 @@ class TestLoadingOtls(TestHooks):
         )
 
     def test_otls_installed(self):
+        """
+        Checks that the otls file get installed correctly in Houdini, and that Houdini
+        reports them as installed.
+        """
         # The alembic app is added and it should have installed two otl files,
         # check that Houdini recognises this.
         alembic_app = self.engine.apps["tk-houdini-alembicnode"]

--- a/tests/test_otl_loading.py
+++ b/tests/test_otl_loading.py
@@ -112,7 +112,11 @@ class TestLoadingOtls(TestHooks):
         alembic_app = self.engine.apps["tk-houdini-alembicnode"]
         otl_path = self.engine._safe_path_join(alembic_app.disk_location, "otls")
 
-        # This should happen when the engine starts up, but for some reason in this test we need to force it.
+        # This would normally happen when the engine starts up, but the
+        # `if bootstrap.g_temp_env in os.environ:` line prevents it from running
+        # during the tests. This might be down to us using a 123.py startup script
+        # I'm not sure at the time of writing.
+        # So we will call it manually.
         self.engine._load_app_otls(self.tank_temp)
 
         # The alembic node should have version folders, so remove root folder from the list,

--- a/tests/test_otl_loading.py
+++ b/tests/test_otl_loading.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import hou
+
+# Required so that the SHOTGUN_HOME env var will be set
+from tank_test.tank_test_base import setUpModule  # noqa
+
+from test_hooks_base import TestHooks
+
+
+class TestLoadingOtls(TestHooks):
+    """
+    Tests the loading Houdini otl files from apps.
+    """
+
+    def setUp(self):
+        super(TestLoadingOtls, self).setUp()
+
+    def __check_paths(self, houdini_version, expected_folders):
+        # Change what the engine thinks the Houdini version is.
+        self.engine._houdini_version = houdini_version
+        # Ask the engine for the otl paths.
+        paths = self.engine._get_otl_paths(self.app_otl_folder)
+        # We would always expect to get the root otl folder returned.
+        expected_folders.insert(0, self.app_otl_folder)
+
+        self.assertEqual(
+            paths,
+            expected_folders,
+            "Houdini version number was: v%s.%s.%s" % houdini_version,
+        )
+
+    def _make_folder(self, folder_name):
+        os.makedirs(os.path.join(self.app_otl_folder, folder_name))
+
+    def test_otl_paths(self):
+        """
+        This tests that the engine will gather the appropriate otl paths from an app path.
+        This doesn't test the actual installing of an otl in Houdini, but it does cover the most complicated
+        part of the process.
+        :return:
+        """
+        # First test that when no version folders exist it only gathers the otls folder.
+        self.app_otl_folder = os.path.join(self.tank_temp, "test_app", "otls")
+        os.makedirs(self.app_otl_folder)
+        # This folder should not be gathered
+        self._make_folder("test")
+        # These version folders don't have the right format so shouldn't be gathered.
+        self._make_folder("v16")
+        self._make_folder("v16.0")
+        self._make_folder("v16.0.0x")
+        self._make_folder("dv16.0.0")
+        self._make_folder("16.0.0")
+        # Now check that only the otls folder was returned.
+        self.__check_paths((17, 0, 0), [])
+
+        self._make_folder("v14.x.x")
+        self._make_folder("v16.x.x")
+        self._make_folder("v18.x.x")
+        self._make_folder("v19.5.x")
+        self._make_folder("v19.6.19")
+        self._make_folder("v20.0.0")
+        # Test it picks the exact or next lowest version folder testing major version numbers specifically
+        self.__check_paths(
+            (17, 1, 1), [os.path.join(self.app_otl_folder, "v16.x.x")],
+        )
+        self.__check_paths(
+            (18, 0, 0), [os.path.join(self.app_otl_folder, "v18.x.x")],
+        )
+        self.__check_paths(
+            (18, 1, 134), [os.path.join(self.app_otl_folder, "v18.x.x")],
+        )
+        # Test it picks the exact or next lowest version folder testing minor version numbers specifically
+        self.__check_paths(
+            (19, 6, 10), [os.path.join(self.app_otl_folder, "v19.5.x")],
+        )
+        # Test it picks the exact or next lowest version folder testing patch version numbers specifically
+        self.__check_paths(
+            (19, 6, 20), [os.path.join(self.app_otl_folder, "v19.6.19")],
+        )
+        self.__check_paths(
+            (20, 1, 2), [os.path.join(self.app_otl_folder, "v20.0.0")],
+        )
+
+    def test_otls_installed(self):
+        # The alembic app is added and it should have installed two otl files,
+        # check that Houdini recognises this.
+        alembic_app = self.engine.apps["tk-houdini-alembicnode"]
+        otl_path = self.engine._safe_path_join(alembic_app.disk_location, "otls")
+
+        # This should happen when the engine starts up, but for some reason in this test we need to force it.
+        self.engine._load_app_otls(self.tank_temp)
+
+        # The alembic node should have version folders, so remove root folder from the list,
+        # and check that we have one path left which will be the version folder.
+        otl_paths = self.engine._get_otl_paths(otl_path)
+        otl_paths.remove(otl_path)
+        self.assertTrue(len(otl_paths) == 1)
+
+        # Now check both otls were installed in Houdini.
+        self.assertTrue(
+            os.path.join(otl_paths[0], "sgtk_alembic.otl") in hou.hda.loadedFiles()
+        )
+        self.assertTrue(
+            os.path.join(otl_paths[0], "sgtk_alembic_sop.otl") in hou.hda.loadedFiles()
+        )


### PR DESCRIPTION
The `tk-houdini` engine is responsible for installing any otl files found in an app.

Before this PR, it just loaded any otl files found inside the bundle's `/otl` folder.
Now it also checks for Houdini version folders inside the otl folder, and loads the otls most appropriate to the current Houdini version.

A version folder would look like this:
`otl/v18.0.0`
or 
`otl/v18.x.x`
Where x can represent any number.
Multiple version folders can be present but the code will only load the otls file from a version folder that is lower or equal to the current Houdini version and is closest to the current Houdini version.

Tests have been written as well to cover this change.

The reason for this change, is it allows us to have version specific otl files.
