### PR TITLE
SG-22393 [tk-houdini] TK_HOUDINI_TMP Not Being Set When "bootstrap_classic()" is called

### DIFF
--- a/python/tk_houdini/bootstrap.py
+++ b/python/tk_houdini/bootstrap.py
@@ -65,6 +65,12 @@ def bootstrap_classic():
         bootstrap_exception("Failed to import 'sgtk'!")
         return
 
+    # get the necessary environment variable for launch
+    env = get_classic_startup_env()
+
+    # update the environment with the classic startup vars
+    os.environ.update(env)
+
     # ensure the engine name and context are defined in the environment
     for env_var in [g_sgtk_context_env, g_sgtk_engine_env]:
         if env_var not in os.environ:


### PR DESCRIPTION
This pr call the "get_classic_startup_env()" method inside "bootstrap_classic()", to set the necessary env variables for a classic startup including the "TK_HOUDINI_TMP" env var.