### PR TITLE
SG-29173 Add support for Houdini 19.5 / Python 3.9

### DIFF
--- a/classic_startup/python3.9libs/pythonrc.py
+++ b/classic_startup/python3.9libs/pythonrc.py
@@ -28,7 +28,13 @@ def classic_startup():
     # helper methods for constructing the proper environment based on the
     # bootstrap scanario. For this file, the python directory is 3 levels up.
     tk_houdini_python_path = os.path.abspath(
-        os.path.join(current_file_path, "..", "..", "..", "python",)
+        os.path.join(
+            current_file_path,
+            "..",
+            "..",
+            "..",
+            "python",
+        )
     )
 
     # add to the system path

--- a/classic_startup/python3.9libs/pythonrc.py
+++ b/classic_startup/python3.9libs/pythonrc.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+This file is loaded automatically by Houdini at startup.
+"""
+
+import inspect
+import os
+import sys
+
+
+def classic_startup():
+
+    # use inspect to get the current file path since attempts to access
+    # __file__ result in a NameError.
+    current_file_path = os.path.abspath(inspect.getsourcefile(lambda: 0))
+
+    # construct the path to the engine's python directory and add it to sys
+    # path. this provides us access to the bootstrap module which contains
+    # helper methods for constructing the proper environment based on the
+    # bootstrap scanario. For this file, the python directory is 3 levels up.
+    tk_houdini_python_path = os.path.abspath(
+        os.path.join(current_file_path, "..", "..", "..", "python",)
+    )
+
+    # add to the system path
+    sys.path.insert(0, tk_houdini_python_path)
+
+    # now that the path is there, we can import the classic bootstrap logic
+    try:
+        from tk_houdini import bootstrap
+
+        bootstrap.bootstrap_classic()
+    except Exception as e:
+        import traceback
+
+        stack_trace = traceback.format_exc()
+
+        message = "SG Toolkit Error: %s" % (e,)
+        details = "Error stack trace:\n\n%s" % (stack_trace)
+
+        import hou
+
+        if hou.isUIAvailable():
+            hou.ui.displayMessage(message, details=details)
+        else:
+            print(message)
+            print(details)
+
+
+classic_startup()

--- a/classic_startup/python3.9libs/pythonrc.py
+++ b/classic_startup/python3.9libs/pythonrc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Shotgun Software Inc.
+# Copyright (c) 2023 ShotGrid Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -22,4 +22,4 @@ files in these folders should be identicial, and should call shared code in
 the plugin's `python` folder to keep the code duplication to a minimum.
 
 For more information on these standard Houdini files,
-[http://www.sidefx.com/docs/houdini/hom/locations](see the official documentation).
+[see the official documentation](http://www.sidefx.com/docs/houdini/hom/locations).

--- a/plugins/basic/python3.9libs/pythonrc.py
+++ b/plugins/basic/python3.9libs/pythonrc.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+This file is loaded automatically by Houdini at startup.
+"""
+
+import inspect
+import os
+import sys
+
+
+def plugin_startup():
+
+    # construct the path to the plugin root's folder.
+    #      plugins/basic/python2.Xlibs/pythonrc.py
+    #      -------------|
+    # this part ^
+
+    # use inspect to get the current file path since attempts to access
+    # __file__ result in a NameError.
+    current_file_path = os.path.abspath(inspect.getsourcefile(lambda: 0))
+
+    current_dir_path = os.path.dirname(current_file_path)
+    plugin_root_path = os.path.dirname(current_dir_path)
+
+    # the plugin python path will be just below the root level. add it to
+    # sys.path
+    plugin_python_path = os.path.join(plugin_root_path, "python")
+    sys.path.insert(0, plugin_python_path)
+
+    # now that the path is there, we can import the plugin bootstrap logic
+    try:
+        from tk_houdini_basic import plugin_bootstrap
+
+        plugin_bootstrap.bootstrap(plugin_root_path)
+    except Exception as e:
+        import traceback
+
+        stack_trace = traceback.format_exc()
+
+        message = "SG Toolkit Error: %s" % (e,)
+        details = "Error stack trace:\n\n%s" % (stack_trace)
+
+        import hou
+
+        if hou.isUIAvailable():
+            hou.ui.displayMessage(message, details=details)
+        else:
+            print(message)
+            print(details)
+
+
+plugin_startup()


### PR DESCRIPTION
This is a fork of #63.

Houdini 19.5 is shipped with Python 3.9. Version 19.0 was shipped with Python 3.7.
