### PR TITLE
SG-32657 Test CI with Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![VFX Platform](https://img.shields.io/badge/vfxplatform-2023%202022%202021%202020-blue.svg)](http://www.vfxplatform.com/)
+[![Python 3.7 3.9 3.10](https://img.shields.io/badge/python-3.7%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-houdini?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=63&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![VFX Platform](https://img.shields.io/badge/vfxplatform-2023%202022%202021%202020-blue.svg)](http://www.vfxplatform.com/)
-[![Python 3.7 3.9 3.10](https://img.shields.io/badge/python-3.7%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org/)
+[![Python 3.7 3.9](https://img.shields.io/badge/python-3.7%20%7C%203.9-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-houdini?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=63&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
     - repository: templates
       type: github
       name: shotgunsoftware/tk-ci-tools
-      ref: refs/heads/master
+      ref: python-310-311
       endpoint: shotgunsoftware
 
 # We want builds to trigger for 3 reasons:
@@ -41,4 +41,4 @@ variables:
 jobs:
 - template: build-pipeline.yml@templates
   parameters:
-    skip_tests: true
+    skip_tests: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
     - repository: templates
       type: github
       name: shotgunsoftware/tk-ci-tools
-      ref: python-310-311
+      ref: refs/heads/master
       endpoint: shotgunsoftware
 
 # We want builds to trigger for 3 reasons:
@@ -41,4 +41,4 @@ variables:
 jobs:
 - template: build-pipeline.yml@templates
   parameters:
-    skip_tests: false
+    skip_tests: true

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@
 To run these tests, you need to do the following (tested on Mac)
 
 1. From a terminal, create a virtual environment (using `virtualenv` even on newer versions of Python) at the specific location of `tests/venv_py3` depending on the version of python you are testing. 
-To create a virtual env for Python 3 do something like this: 
+To create a virtual env for Python 3 do something like this:
 
 ```
 virtualenv --python=/Users/username/.pyenv/versions/3.7.6/bin/python3 venv_py3
@@ -16,19 +16,19 @@ virtualenv --python=/Users/username/.pyenv/versions/3.7.6/bin/python3 venv_py3
 source venv_p3/bin/activate
 ```
 
-3. Install all dependencies needed for the test: 
+3. Install all dependencies needed for the test:
 
 ```
 pip install -r requirements.txt
 ```
 
-4. In the command line, set the `HOUDINI_PATH` env var to point to this test folder: 
+4. In the command line, set the `HOUDINI_PATH` env var to point to this test folder:
 
 ```
 export HOUDINI_PATH="/Users/philips1/source_code/tk-houdini/tests;&"
 ``` 
 
-on Mac, or 
+on Mac, or
 
 ```
 set "HOUDINI_PATH=E:\code\tk-houdini\tests;&"

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,10 +3,45 @@
 
 To run these tests, you need to do the following (tested on Mac)
 
-1. From a terminal, create a virtual environment (using `virtualenv`) at `tests/venv_py2` or `tests/venv_py3` depending on the version of python you are testing. To create a virtual env for python 3 do something like this: `virtualenv --python=/Users/username/.pyenv/versions/3.7.6/bin/python3 venv_py3`
-2. Execute `source venv_py2|3/bin/activate` on mac, or on Windows cd into `venv_py2|3/bin` and run `activate.bat`.
-3. Install all dependencies needed for the test: `pip install -r requirements.txt`.
+1. From a terminal, create a virtual environment (using `virtualenv` even on newer versions of Python) at the specific location of `tests/venv_py3` depending on the version of python you are testing. 
+To create a virtual env for Python 3 do something like this: 
 
-4. In the command line, set the `HOUDINI_PATH` env var to point to this test folder: `export HOUDINI_PATH="/Users/philips1/source_code/tk-houdini/tests;&"` on Mac, or `set "HOUDINI_PATH=E:\code\tk-houdini\tests;&"` on Windows, (make sure you include the `;&` at the end and wrap the value in quotes.)
-5. Launch Houdini via the same terminal you set the env var in, eg: `/Applications/Houdini/Houdini18.0.392/Houdini\ FX\ 18.0.392.app/Contents/MacOS/houdini`. It should then run the tests and dump the output to the shell and then close Houdini automatically.
-  To run the tests via hython (to test without a UI) do everything the same, but instead of calling the Houdini app call hython: `/Applications/Houdini/Houdini18.0.348/Frameworks/Houdini.framework/Versions/18.0/Resources/bin/hython`.
+```
+virtualenv --python=/Users/username/.pyenv/versions/3.7.6/bin/python3 venv_py3
+```
+
+2. Activate the virtual environment.
+
+```
+source venv_p3/bin/activate
+```
+
+3. Install all dependencies needed for the test: 
+
+```
+pip install -r requirements.txt
+```
+
+4. In the command line, set the `HOUDINI_PATH` env var to point to this test folder: 
+
+```
+export HOUDINI_PATH="/Users/philips1/source_code/tk-houdini/tests;&"
+``` 
+
+on Mac, or 
+
+```
+set "HOUDINI_PATH=E:\code\tk-houdini\tests;&"
+```
+
+on Windows, (make sure you include the `;&` at the end and wrap the value in quotes.)
+
+5. Launch Houdini via the same terminal you set the env var in. Houdini should have a valid license enabled.
+
+```
+/Applications/Houdini/Houdini18.0.392/Houdini\ FX\ 18.0.392.app/Contents/MacOS/houdini
+```
+
+It should then run the tests and dump the output to the shell and then close Houdini automatically.
+
+> To run the tests via hython (to test without a UI) do everything the same, but instead of calling the Houdini app call hython: `/Applications/Houdini/Houdini18.0.348/Frameworks/Houdini.framework/Versions/18.0/Resources/bin/hython`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,7 +3,7 @@
 
 To run these tests, you need to do the following (tested on Mac)
 
-1. From a terminal, create a virtual environment (using `virtualenv` even on newer versions of Python) at the specific location of `tests/venv_py3` depending on the version of python you are testing. 
+1. From a terminal, create a virtual environment (using `virtualenv` even on newer versions of Python) at the specific location of `tests/venv_py3` depending on the version of python you are testing.
 To create a virtual env for Python 3 do something like this:
 
 ```
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 
 ```
 export HOUDINI_PATH="/Users/philips1/source_code/tk-houdini/tests;&"
-``` 
+```
 
 on Mac, or
 

--- a/tests/test_tk_multi_loader2_hooks.py
+++ b/tests/test_tk_multi_loader2_hooks.py
@@ -59,7 +59,7 @@ class TestLoader2Hooks(TestHooks):
         publish = {
             "published_file_type": {"type": "PublishedFileType", "name": publish_type}
         }
-        return self.action_manager._get_actions_for_publish(
+        return self.action_manager.get_actions_for_publish(
             publish, self.action_manager.UI_AREA_MAIN
         )
 
@@ -70,7 +70,7 @@ class TestLoader2Hooks(TestHooks):
         # Test that given a PublishedFileType it will generate a single action for import
         actions = self._publish_type_actions(publish_type)
         self.assertTrue(len(actions) == 1)
-        self.assertTrue(actions[0]["name"] == action)
+        self.assertTrue(actions[0].text().lower().replace(" ", "_") == action)
 
     def test_generate_actions(self):
         """


### PR DESCRIPTION
Tests cannot be run on CI because they need a working environment of Houdini.

However, I run the tests using virtual environments with Python 3.9 and 3.10. Only one tests needed update.

```
 $ /Applications/Houdini/Houdini19.5.682/Houdini\ FX\ 19.5.682.app/Contents/MacOS/houdini




Python running from /Applications/Houdini/Houdini19.5.682/Houdini FX 19.5.682.app/Contents/MacOS/houdini
Repository found at /Users/masked-user/tk-houdini
Adding Toolkit folder: /Users/masked-user/tk-core/python
Logs for this test run can be found at /Users/masked-user/Library/Logs/Shotgun/tk-test.log
Adding Toolkit test framework: /Users/masked-user/tk-core/tests/python
Adding repository tests/python folder: /Users/masked-user/tk-houdini/tests/python
Fixtures found at /Users/masked-user/tk-houdini/tests/fixtures
===================================================================================================== test session starts ======================================================================================================
platform darwin -- Python 3.9.10, pytest-4.6.6, py-1.11.0, pluggy-0.13.1 -- /Applications/Houdini/Houdini19.5.682/Houdini FX 19.5.682.app/Contents/MacOS/houdini
cachedir: .pytest_cache
rootdir: /Users/masked-user/tk-houdini, inifile: pytest.ini
plugins: tk-toolchain-0.2.0.dev0, cov-4.0.0
collected 13 items                                                                                                                                                                                                             

tests/test_otl_loading.py::TestLoadingOtls::test_otl_paths 
==============================================================================================
Toolkit test data location: /var/folders/nl/qc4v168558z9lv8_65bwg09h0000gn/T/TestData_v0tmfcjj
==============================================================================================

PASSED
tests/test_otl_loading.py::TestLoadingOtls::test_otls_installed PASSED
tests/test_tk_multi_loader2_hooks.py::TestLoader2Hooks::test_execute_merge_action 
==============================================================================================
Toolkit test data location: /var/folders/nl/qc4v168558z9lv8_65bwg09h0000gn/T/TestData_xeds09fd
==============================================================================================

PASSED
tests/test_tk_multi_loader2_hooks.py::TestLoader2Hooks::test_generate_actions PASSED
tests/test_tk_multi_setframerange_hooks.py::TestFrameRangeHooks::test_get_frame_range 
==============================================================================================
Toolkit test data location: /var/folders/nl/qc4v168558z9lv8_65bwg09h0000gn/T/TestData_e9e4zl_3
==============================================================================================

PASSED
tests/test_tk_multi_setframerange_hooks.py::TestFrameRangeHooks::test_set_frame_range PASSED
tests/test_tk_multi_snapshot_hooks.py::TestSnapShotHooks::test_create_snapshot 
==============================================================================================
Toolkit test data location: /var/folders/nl/qc4v168558z9lv8_65bwg09h0000gn/T/TestData_lrp9g0iw
==============================================================================================

PASSED
tests/test_tk_multi_snapshot_hooks.py::TestSnapShotHooks::test_load_snapshot PASSED
tests/test_tk_multi_workfiles2_hooks.py::TestWorkfiles2Hooks::test_get_current_path 
==============================================================================================
Toolkit test data location: /var/folders/nl/qc4v168558z9lv8_65bwg09h0000gn/T/TestData_q1w4dh02
==============================================================================================

PASSED
tests/test_tk_multi_workfiles2_hooks.py::TestWorkfiles2Hooks::test_open_file PASSED
tests/test_tk_multi_workfiles2_hooks.py::TestWorkfiles2Hooks::test_prepare_new_scene PASSED
tests/test_tk_multi_workfiles2_hooks.py::TestWorkfiles2Hooks::test_reset PASSED
tests/test_tk_multi_workfiles2_hooks.py::TestWorkfiles2Hooks::test_save_file PASSED

/Users/masked-user/tk-houdini/tests/venv_py3/lib/python3.10/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/masked-user/tk-houdini/hou.session': No source for code: '/Users/masked-user/tk-houdini/hou.session'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/masked-user/tk-houdini/tests/venv_py3/lib/python3.10/site-packages/coverage/report.py:81: CoverageWarning: Couldn't parse Python file '/Users/masked-user/tk-houdini/python/packages/httplib.py' (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/masked-user/tk-houdini/tests/venv_py3/lib/python3.10/site-packages/coverage/report.py:81: CoverageWarning: Couldn't parse Python file '/Users/masked-user/tk-houdini/python/packages/urllib2.py' (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")


---------- coverage: platform darwin, python 3.9.10-final-0 ----------
Coverage HTML written to dir htmlcov


================================================================================================== 13 passed in 29.14 seconds ==================================================================================================

Test run stats
==============
TankTestBase.setUp : 1.3800525665283203 (13 hits, 0.106 avg)
TankTestBase.setup_fixtures : 0.5540375709533691 (13 hits, 0.043 avg)
TankTestBase.tearDown : 0.34413647651672363 (13 hits, 0.026 avg)
setUpModule : 0.01157832145690918 (5 hits, 0.002 avg)
Time spent in tracked methods: 2.2898049354553223


```