### PR TITLE
SG-35133 Fix infinite loop for multiple panels

### DIFF
--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -886,13 +886,6 @@ def get_wrapped_panel_widget(engine, widget_class, bundle, title):
                         self.setStyleSheet(self.styleSheet() + qss_data)
                         self.update()
 
-                    # We have some funky qss behavior in H16 that requires us to
-                    # kick the parent's stylesheet by reassigning it as is. Not
-                    # sure what causes the problem, but this does resolve it. The
-                    # original symptoms were some widgets not changing after applying
-                    # the engine's stylesheet, while others did.
-                    if self.parent():
-                        self.parent().setStyleSheet(self.parent().styleSheet())
             except Exception as e:
                 engine.logger.warning(
                     "Unable to re-apply stylesheet for panel: %s %s" % (title, e)


### PR DESCRIPTION
**Note:** Only applies on Windows and Linux, when panels are available on Houdini ≥ 15.0.272

When opening multiple panels on Houdini (e.g. FPTR Panel + Breakdown) it triggers an infinity StyleChange event to other parent panel apps.

Removing this line fixes this and the styling is preserved, so probably this was required for older versions of Houdini. Tested on versions 20 and 19.5.

This requires QA on the supported versions.

![Screenshot 2024-05-06 at 9 40 26 AM](https://github.com/shotgunsoftware/tk-houdini/assets/123113322/a9cdde69-00ff-4e24-97c1-3673e9cc9c12)
