### PR TITLE
SG-35286 Create a setting to have short menu name

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -91,6 +91,10 @@ class HoudiniEngine(sgtk.platform.Engine):
             if self.get_setting("automatic_context_switch", True):
                 tk_houdini.ensure_file_change_timer_running()
 
+        self._menu_name = "Flow Production Tracking"
+        if self.get_setting("use_short_menu_name", False):
+            self._menu_name = "FPTR"
+
     def post_app_init(self):
         """
         Init that runs after all apps have been loaded.
@@ -153,10 +157,6 @@ class HoudiniEngine(sgtk.platform.Engine):
                 # as of houdini 12.5 add .xml
                 if self._houdini_version > (12, 5, 0):
                     menu_file = menu_file + ".xml"
-
-                self._menu_name = "Flow Production Tracking"
-                if self.get_setting("use_short_menu_name", False):
-                    self._menu_name = "FPTR"
 
                 # keep the reference to the menu handler for convenience so
                 # that we can access it from the menu scripts when they get

--- a/engine.py
+++ b/engine.py
@@ -154,6 +154,10 @@ class HoudiniEngine(sgtk.platform.Engine):
                 if self._houdini_version > (12, 5, 0):
                     menu_file = menu_file + ".xml"
 
+                self._menu_name = "Flow Production Tracking"
+                if self.get_setting("use_short_menu_name", False):
+                    self._menu_name = "FPTR"
+
                 # keep the reference to the menu handler for convenience so
                 # that we can access it from the menu scripts when they get
                 # ahold of the current engine.

--- a/info.yml
+++ b/info.yml
@@ -37,6 +37,11 @@ configuration:
                      rebuilt dynamically as the Flow Production Tracking context changes."
         default_value: true
 
+    use_short_menu_name:
+        type: bool
+        description: Optionally choose to use "FPTR" as the primary menu name instead of "Flow Production Tracking"
+        default_value: false
+
     debug_logging:
         type: bool
         description: Controls whether debug messages should be emitted to the logger

--- a/python/tk_houdini/ui_generation.py
+++ b/python/tk_houdini/ui_generation.py
@@ -221,7 +221,12 @@ class AppCommandsMenu(AppCommandsUI):
 
         root = ET.Element("mainMenu")
         menubar = ET.SubElement(root, "menuBar")
-        shotgun_menu = self._menuNode(menubar, "Flow Production Tracking", "tk.shotgun")
+        shotgun_menu = self._menuNode(
+            menubar,
+            self._engine._menu_name,
+            "tk.shotgun",
+        )
+
         insert_before = ET.SubElement(shotgun_menu, "insertBefore")
         insert_before.text = "help_menu"
 


### PR DESCRIPTION
Create a `use_short_menu_name` setting which makes the primary menu name to be "FPTR" instead of "Flow Production Tracking".
