### PR TITLE
SG-42798 digital asset option restored

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -401,17 +401,27 @@ Please report any issues to:
     def post_context_change(self, old_context, new_context):
         """
         Runs after a context change. Updates the menu and shelf to reflect
-        the new context.
+        the new context, and reloads OTLs for apps that may only be active
+        in the new context (e.g. tk-houdini-alembicnode, tk-houdini-mantranode).
 
         :param old_context: The context being changed away from.
         :param new_context: The new context being changed to.
         """
         self.logger.debug("Post context change: %s -> %s" % (old_context, new_context))
 
+        tk_houdini = self.import_module("tk_houdini")
+        bootstrap = tk_houdini.bootstrap
+
+        # Reload OTLs so apps that only activate in a task context (e.g.
+        # alembic/mantra nodes) have their Digital Assets registered. Without
+        # this, context_change_allowed=True prevents post_app_init from being
+        # called again, leaving those OTLs uninstalled.
+        if bootstrap.g_temp_env in os.environ:
+            oplibrary_path = os.environ[bootstrap.g_temp_env].replace("\\", "/")
+            self._load_app_otls(oplibrary_path)
+
         # Update the menu and shelf to reflect the new context
         if self.has_ui:
-            tk_houdini = self.import_module("tk_houdini")
-
             # Get new commands for the updated context
             commands = tk_houdini.get_registered_commands(self)
             self._callback_map = dict((cmd.get_id(), cmd.callback) for cmd in commands)


### PR DESCRIPTION
The `post_context_change` method was not reloading OTLs after a context switch,
causing the **Digital Assets** option (Alembic and Mantra nodes) to disappear
from Houdini's TAB menu when opening or creating a file under a task.

## Root cause

PR #98 introduced `context_change_allowed = True` on the engine, which prevents
tk-core from restarting the engine on a context change. As a side effect,
`post_app_init` is never called again after the initial startup, so apps that
are only active in a task context (e.g. `tk-houdini-alembicnode`,
`tk-houdini-mantranode`) never have their OTLs installed when the context
switches to a task.

## Changes

- Updated `post_context_change` to call `_load_app_otls` after each context
  change, mirroring the behavior of `post_app_init`. This ensures OTLs for
  task-context-only apps are registered even when the engine is not restarted.
- OTL reloading runs outside the `has_ui` guard, consistent with `post_app_init`,
  so it also works correctly in headless/batch sessions.
- Menu and shelf refresh behavior is unchanged.

Fixes regression introduced by #98.